### PR TITLE
PR: Add Verovio Layout Options for Page and System Break Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A lightweight web component that renders MEI (Music Encoding Initiative) files a
 - **MEI Rendering**: Full support for MEI file rendering via Verovio toolkit
 - **Page Navigation**: Navigate through multi-page scores
 - **Zoom Control**: Adjustable zoom levels (10-100%)
-- **Layout Control**: Control page and system breaks with configurable break modes
+- **Break Control**: Configurable page and system break modes (`auto`, `none`, `line`, `smart`, `encoded`)
 - **Element Navigation**: Jump to specific measures, movements, or XML elements
 - **Multi-Movement Support**: Navigate between movements (mdiv sections)
 - **Customizable Options**: Full access to Verovio rendering options
@@ -68,8 +68,14 @@ renderer.setAttribute('measurenumber', '10');
 // Adjust zoom
 renderer.setAttribute('zoom', '60');
 
-// Change break mode
-renderer.setAttribute('break-mode', 'encoded');
+// Change break mode (auto, none, line, smart, or encoded)
+renderer.setAttribute('breakmode', 'encoded');
+
+// Update Verovio options dynamically
+renderer.setAttribute('verovio-options', JSON.stringify({
+  spacingStaff: 10,
+  breaks: 'smart'
+}));
 ``` 
 
 ## API Reference
@@ -101,9 +107,9 @@ All attributes are strings. The component automatically converts values to the a
 
 | Attribute | Type | Description | Default |
 |-----------|------|-------------|---------|
-| `break-mode` | String | Control page and system breaks: `auto`, `none`, `line`, `smart`, `encoded` | `"auto"` |
+| `breakmode` | String | Control page and system breaks: `auto`, `none`, `line`, `smart`, `encoded` | `"auto"` |
 | `verovio-url` | String | URL to Verovio toolkit JavaScript file | `"https://www.verovio.org/javascript/5.3.2/verovio-toolkit-wasm.js"` |
-| `verovio-options` | Object/String | Verovio toolkit options (JSON string or object) | See below |
+| `verovio-options` | Object/String | Verovio toolkit options (JSON string or object) - dynamically updates rendering | See below |
 | `pagewidth` | Number | Page width in Verovio units (100-100000) | Calculated from `width` and `zoom` |
 | `pageheight` | Number | Page height in Verovio units (100-60000) | Calculated from `height` and `zoom` |
 
@@ -113,6 +119,8 @@ All attributes are strings. The component automatically converts values to the a
 - `line` - Text-wrap style line breaks without forced page breaks
 - `smart` - Intelligent break placement based on musical structure and phrases
 - `encoded` - Respects explicit `<pb/>` (page break) and `<sb/>` (system break) markers in the MEI file
+
+**Note:** The `breakmode` attribute directly controls Verovio's `breaks` option. You can also set it via `verovio-options`, but using the dedicated `breakmode` attribute is recommended for clarity.
 
 #### Default Verovio Options
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A lightweight web component that renders MEI (Music Encoding Initiative) files a
 - **MEI Rendering**: Full support for MEI file rendering via Verovio toolkit
 - **Page Navigation**: Navigate through multi-page scores
 - **Zoom Control**: Adjustable zoom levels (10-100%)
+- **Layout Control**: Control page and system breaks with configurable break modes
 - **Element Navigation**: Jump to specific measures, movements, or XML elements
 - **Multi-Movement Support**: Navigate between movements (mdiv sections)
 - **Customizable Options**: Full access to Verovio rendering options
@@ -66,6 +67,9 @@ renderer.setAttribute('measurenumber', '10');
 
 // Adjust zoom
 renderer.setAttribute('zoom', '60');
+
+// Change break mode
+renderer.setAttribute('break-mode', 'encoded');
 ``` 
 
 ## API Reference
@@ -97,16 +101,24 @@ All attributes are strings. The component automatically converts values to the a
 
 | Attribute | Type | Description | Default |
 |-----------|------|-------------|---------|
+| `break-mode` | String | Control page and system breaks: `auto`, `none`, `line`, `smart`, `encoded` | `"auto"` |
 | `verovio-url` | String | URL to Verovio toolkit JavaScript file | `"https://www.verovio.org/javascript/5.3.2/verovio-toolkit-wasm.js"` |
 | `verovio-options` | Object/String | Verovio toolkit options (JSON string or object) | See below |
 | `pagewidth` | Number | Page width in Verovio units (100-100000) | Calculated from `width` and `zoom` |
 | `pageheight` | Number | Page height in Verovio units (100-60000) | Calculated from `height` and `zoom` |
 
+**Break Mode Reference:**
+- `auto` - Default mode. Respects page dimensions and automatically calculates optimal page/system breaks
+- `none` - Single continuous system; page width adjusts automatically to fit all content
+- `line` - Text-wrap style line breaks without forced page breaks
+- `smart` - Intelligent break placement based on musical structure and phrases
+- `encoded` - Respects explicit `<pb/>` (page break) and `<sb/>` (system break) markers in the MEI file
+
 #### Default Verovio Options
 
 ```javascript
 {
-  breaks: "auto",
+  breaks: "auto",           // Controlled via break-mode attribute
   scale: 20,
   spacingStaff: 7,
   pageHeight: 4500,

--- a/edirom-verovio-renderer-component.js
+++ b/edirom-verovio-renderer-component.js
@@ -47,7 +47,7 @@ class EdiromVerovioRenderer extends HTMLElement {
     /** set global properties */
     this.veroviourl = this.getAttribute('verovio-url') || "https://www.verovio.org/javascript/5.3.2/verovio-toolkit-wasm.js";    
     this.options = this.getAttribute("verovio-options") || {
-      breaks: this.getAttribute('break-mode') || "auto",
+      breaks: this.getAttribute('breakmode') || "auto",
       scale: 20,
       spacingStaff: 7,
       pageHeight: 4500,
@@ -94,7 +94,7 @@ class EdiromVerovioRenderer extends HTMLElement {
    * @returns {Array<string>} The list of observed attributes.
    */
   static get observedAttributes() {
-    return ['zoom', 'height', 'width', 'pagenumber', 'meiurl', 'elementid', 'measurenumber', 'mdivname', "movementid", "pagewidth", "pageheight", "verovio-url", "verovio-options", "break-mode"];
+    return ['zoom', 'height', 'width', 'pagenumber', 'meiurl', 'elementid', 'measurenumber', 'mdivname', "movementid", "pagewidth", "pageheight", "verovio-url", "verovio-options", "breakmode"];
   }
 
   /**
@@ -213,11 +213,25 @@ class EdiromVerovioRenderer extends HTMLElement {
         }
         break;
 
-      case 'break-mode':
+      case 'breakmode':
         this.options['breaks'] = newPropertyValue;
         this.tk?.setOptions(this.options);
         this.tk?.loadData(this.meiData);
         this.renderSVG();
+        break;
+
+      case 'verovio-options':
+        try {
+          const newOptions = typeof newPropertyValue === 'string' 
+            ? JSON.parse(newPropertyValue) 
+            : newPropertyValue;
+          this.options = { ...this.options, ...newOptions };
+          this.tk?.setOptions(this.options);
+          this.tk?.loadData(this.meiData);
+          this.renderSVG();
+        } catch (e) {
+          console.error('Invalid verovio-options format:', e);
+        }
         break;
     }
 

--- a/edirom-verovio-renderer-component.js
+++ b/edirom-verovio-renderer-component.js
@@ -47,7 +47,7 @@ class EdiromVerovioRenderer extends HTMLElement {
     /** set global properties */
     this.veroviourl = this.getAttribute('verovio-url') || "https://www.verovio.org/javascript/5.3.2/verovio-toolkit-wasm.js";    
     this.options = this.getAttribute("verovio-options") || {
-      breaks: "auto",
+      breaks: this.getAttribute('break-mode') || "auto",
       scale: 20,
       spacingStaff: 7,
       pageHeight: 4500,
@@ -94,7 +94,7 @@ class EdiromVerovioRenderer extends HTMLElement {
    * @returns {Array<string>} The list of observed attributes.
    */
   static get observedAttributes() {
-    return ['zoom', 'height', 'width', 'pagenumber', 'meiurl', 'elementid', 'measurenumber', 'mdivname', "movementid", "pagewidth", "pageheight", "verovio-url", "verovio-options"];
+    return ['zoom', 'height', 'width', 'pagenumber', 'meiurl', 'elementid', 'measurenumber', 'mdivname', "movementid", "pagewidth", "pageheight", "verovio-url", "verovio-options", "break-mode"];
   }
 
   /**
@@ -211,6 +211,13 @@ class EdiromVerovioRenderer extends HTMLElement {
           this.tk?.loadData(this.meiData);
           this.renderSVG();
         }
+        break;
+
+      case 'break-mode':
+        this.options['breaks'] = newPropertyValue;
+        this.tk?.setOptions(this.options);
+        this.tk?.loadData(this.meiData);
+        this.renderSVG();
         break;
     }
 
@@ -406,7 +413,7 @@ class EdiromVerovioRenderer extends HTMLElement {
    */
   renderSVG() {
     this.totalPages = this.tk?.getPageCount();
-    this.pageNumber = (!isNaN(this.pageNumber) && !isNaN(this.totalPages) && this.pageNumber >= 1 && this.pagenumber <= this.totalPages) ? this.pageNumber : 1;
+    this.pageNumber = (!isNaN(this.pageNumber) && !isNaN(this.totalPages) && this.pageNumber >= 1 && this.pageNumber <= this.totalPages) ? this.pageNumber : 1;
 
     let svg = this.tk?.renderToSVG(this.pageNumber);
     this.shadowRoot.getElementById("verovio-svg").innerHTML = svg;


### PR DESCRIPTION
Implements configurable layout options for controlling how Verovio renders page and system breaks in MEI music notation files. Adds support for all five Verovio break modes with a user-friendly `break-mode` HTML attribute.

## Testing the Break Mode Feature

Test the different break modes using the  
[web component demonstrator](https://edirom.github.io/edirom-web-components/demos/edirom-verovio-renderer.html).

> **Note:** The MEI file used below is **only an example**.  
> You can test the break modes with **any valid MEI file** by providing its URL.

### Step-by-Step Testing Instructions

1. **Open the demonstrator**  
   https://edirom.github.io/edirom-web-components/demos/edirom-verovio-renderer.html

2. **Load an MEI file**
   - In the **“MEI URL”** input field, paste an MEI file URL  
   - Example test file:
     ```
     https://raw.githubusercontent.com/music-encoding/sample-encodings/refs/heads/main/MEI_5.1/Music/Music_structure/multiple_sectionsI.mei
     ```

   - This example file contains **3 `<pb>` elements**, resulting in **4 pages** when page breaks are respected.

3. **Test each break mode**

#### Option A — Using the `break-mode` attribute
- Find the **“break-mode”** input field
- Enter one of:
  - `auto`
  - `encoded`
  - `none`
  - `smart`
  - `line`

#### Option B — Using the `verovio-options` input
- In the **“Verovio Options”** JSON input box, add:

```json
{
  "breaks": "auto"
}
```
Replace "auto" with any of: "encoded", "none", "smart", or "line"

Expected Results

| Break Mode | Expected Behavior                                   | Pages  |
|-----------|------------------------------------------------------|--------|
| `auto`    | Automatic rendering based on page dimensions          | -  |
| `encoded` | Uses the 3 `<pb>` elements from the MEI file          | 4      |
| `none`    | Everything on one page, no breaks                     | 1      |
| `smart`   | Systematic breaks based on musical structure          | Varies |
| `line`    | System breaks only (no page breaks)                   | 1      |

Note: For encoded mode, you'll see exactly 4 pages because this MEI file contains 3 page break markers.
