### PR TITLE
ftr Issue #10  provide different rendering options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ cd edirom-verovio-renderer
 <body>
     <edirom-verovio-renderer
         meiurl="https://www.verovio.org/examples/downloads/Schubert_Lindenbaum.mei"
-        zoom="40"
-        width="800px"
-        height="1000px">
+        zoom="40">
     </edirom-verovio-renderer>
 </body>
 </html>
@@ -69,7 +67,7 @@ renderer.setAttribute('measurenumber', '10');
 renderer.setAttribute('zoom', '60');
 
 // Change break mode (auto, none, line, smart, or encoded)
-renderer.setAttribute('breakmode', 'encoded');
+renderer.setAttribute('verovio-breaks', 'encoded');
 
 // Update Verovio options dynamically
 renderer.setAttribute('verovio-options', JSON.stringify({
@@ -89,8 +87,7 @@ All attributes are strings. The component automatically converts values to the a
 | Attribute | Type | Description | Default |
 |-----------|------|-------------|---------|
 | `meiurl` | String | URL to the MEI file to render | `"https://www.verovio.org/examples/downloads/Schubert_Lindenbaum.mei"` |
-| `width` | String | Component width (with units, e.g., "800px") | `"200px"` |
-| `height` | String | Component height (with units, e.g., "1000px") | `"700px"` |
+
 | `zoom` | Number | Zoom level / Verovio scale (10-100) | `20` |
 | `pagenumber` | Number | Current page to display | `1` |
 
@@ -107,7 +104,7 @@ All attributes are strings. The component automatically converts values to the a
 
 | Attribute | Type | Description | Default |
 |-----------|------|-------------|---------|
-| `breakmode` | String | Control page and system breaks: `auto`, `none`, `line`, `smart`, `encoded` | `"auto"` |
+| `verovio-breaks` | String | Control page and system breaks: `auto`, `none`, `line`, `smart`, `encoded` | `"auto"` |
 | `verovio-url` | String | URL to Verovio toolkit JavaScript file | `"https://www.verovio.org/javascript/5.3.2/verovio-toolkit-wasm.js"` |
 | `verovio-options` | Object/String | Verovio toolkit options (JSON string or object) - dynamically updates rendering | See below |
 | `pagewidth` | Number | Page width in Verovio units (100-100000) | Calculated from `width` and `zoom` |
@@ -120,13 +117,13 @@ All attributes are strings. The component automatically converts values to the a
 - `smart` - Intelligent break placement based on musical structure and phrases
 - `encoded` - Respects explicit `<pb/>` (page break) and `<sb/>` (system break) markers in the MEI file
 
-**Note:** The `breakmode` attribute directly controls Verovio's `breaks` option. You can also set it via `verovio-options`, but using the dedicated `breakmode` attribute is recommended for clarity.
+**Note:** The `verovio-breaks` attribute directly controls Verovio's `breaks` option. You can also set it via `verovio-options`, but using the dedicated `verovio-breaks` attribute is recommended for clarity.
 
 #### Default Verovio Options
 
 ```javascript
 {
-  breaks: "auto",           // Controlled via break-mode attribute
+  breaks: "auto",           // Controlled via verovio-breaks attribute
   scale: 20,
   spacingStaff: 7,
   pageHeight: 4500,
@@ -185,7 +182,7 @@ renderer.gotoMdiv('Allegro');
 ```bash
 # Clone the repository
 git clone https://github.com/Edirom/edirom-verovio-renderer.git
-cd edirom-verovio-renderer
+cd edirom-verovio-renderer 
 
 # Start a local server (Python example)
 python3 -m http.server 8080

--- a/edirom-verovio-renderer-component.js
+++ b/edirom-verovio-renderer-component.js
@@ -165,6 +165,9 @@ class EdiromVerovioRenderer extends HTMLElement {
         break;
 
       case 'height':
+        this[property] = parseInt(newPropertyValue);
+        this.updatePageDimensions();
+        break;
       case 'width':
         this[property] = parseInt(newPropertyValue);
         this.updatePageDimensions();
@@ -362,15 +365,19 @@ class EdiromVerovioRenderer extends HTMLElement {
 	  var context = this;
 	  var later = function() {
 		  timeout = null;
-      context.pageHeight = (context.height != null ? parseInt(context.height.toString().replaceAll("px", "")) * 100 / context.zoom : context.verovioElement?.clientHeight);
-      context.pageWidth = (context.width != null ? parseInt(context.width.toString().replaceAll("px", "")) * 100 / context.zoom : context.verovioElement?.clientWidth);
+      
+      // Only use explicit height/width if set to prevent recursive dimension changes on responsive screens
+      if (context.height != null && context.width != null) {
+        context.pageHeight = parseInt(context.height.toString().replaceAll("px", "")) * 100 / context.zoom;
+        context.pageWidth = parseInt(context.width.toString().replaceAll("px", "")) * 100 / context.zoom;
 
-      context.options['pageHeight'] = parseInt(context.pageHeight);
-      context.options['pageWidth'] = parseInt(context.pageWidth);
-      context.tk?.setOptions(context.options);
+        context.options['pageHeight'] = parseInt(context.pageHeight);
+        context.options['pageWidth'] = parseInt(context.pageWidth);
+        context.tk?.setOptions(context.options);
 
-      context.tk?.loadData(context.meiData);
-      context.renderSVG();
+        context.tk?.loadData(context.meiData);
+        context.renderSVG();
+      }
 	  };
 
 	  clearTimeout(timeout);

--- a/edirom-verovio-renderer-component.js
+++ b/edirom-verovio-renderer-component.js
@@ -47,20 +47,16 @@ class EdiromVerovioRenderer extends HTMLElement {
     /** set global properties */
     this.veroviourl = this.getAttribute('verovio-url') || "https://www.verovio.org/javascript/5.3.2/verovio-toolkit-wasm.js";    
     this.options = this.getAttribute("verovio-options") || {
-      breaks: this.getAttribute('breakmode') || "auto",
-      scale: 20,
-      spacingStaff: 7,
-      pageHeight: 4500,
-      pageWidth: 4500,
-      footer: "none",
-      header: "none",
     }; 
 
     this.meiurl = this.getAttribute('meiurl') || "";
     this.zoom = this.getAttribute("zoom") || 20;
     this.pageNumber = this.getAttribute("pagenumber") || 1;
 
-    this.shadowRoot.innerHTML += `<div id="verovio-svg"></div>`;
+    this.shadowRoot.innerHTML += `
+     
+      <div id="verovio-svg"></div>
+    `;
   }
 
   
@@ -94,7 +90,7 @@ class EdiromVerovioRenderer extends HTMLElement {
    * @returns {Array<string>} The list of observed attributes.
    */
   static get observedAttributes() {
-    return ['zoom', 'height', 'width', 'pagenumber', 'meiurl', 'elementid', 'measurenumber', 'mdivname', "movementid", "pagewidth", "pageheight", "verovio-url", "verovio-options", "breakmode"];
+    return ['zoom', 'pagenumber', 'meiurl', 'elementid', 'measurenumber', 'mdivname', "movementid", "pagewidth", "pageheight", "verovio-url", "verovio-options", "verovio-breaks"];
   }
 
   /**
@@ -164,15 +160,6 @@ class EdiromVerovioRenderer extends HTMLElement {
         this.renderSVG();
         break;
 
-      case 'height':
-        this[property] = parseInt(newPropertyValue);
-        this.updatePageDimensions();
-        break;
-      case 'width':
-        this[property] = parseInt(newPropertyValue);
-        this.updatePageDimensions();
-        break;
-
       case 'meiurl':
         this.meiurl = newPropertyValue;
         this.fetchAndRenderMEI();
@@ -216,7 +203,7 @@ class EdiromVerovioRenderer extends HTMLElement {
         }
         break;
 
-      case 'breakmode':
+      case 'verovio-breaks':
         this.options['breaks'] = newPropertyValue;
         this.tk?.setOptions(this.options);
         this.tk?.loadData(this.meiData);
@@ -366,7 +353,6 @@ class EdiromVerovioRenderer extends HTMLElement {
 	  var later = function() {
 		  timeout = null;
       
-      // Only use explicit height/width if set to prevent recursive dimension changes on responsive screens
       if (context.height != null && context.width != null) {
         context.pageHeight = parseInt(context.height.toString().replaceAll("px", "")) * 100 / context.zoom;
         context.pageWidth = parseInt(context.width.toString().replaceAll("px", "")) * 100 / context.zoom;
@@ -438,7 +424,36 @@ class EdiromVerovioRenderer extends HTMLElement {
 
     let svg = this.tk?.renderToSVG(this.pageNumber);
     this.shadowRoot.getElementById("verovio-svg").innerHTML = svg;
+    const svgElement = this.shadowRoot.querySelector("svg");
+    
+    // Calculate SVG dimensions based on viewBox
+    const viewBox = svgElement.getAttribute('viewBox');
+    
+    if (viewBox) {
+      // Parse viewBox string: "minX minY width height"
+      const viewBoxParts = viewBox.split(' ').map(Number);
+      const vbWidth = viewBoxParts[2];
+      const vbHeight = viewBoxParts[3];
+      
+      if (!isNaN(vbWidth) && !isNaN(vbHeight) && vbWidth > 0 && vbHeight > 0) {
+        // Calculate aspect ratio
+        const aspectRatio = vbHeight / vbWidth;
+        
 
+        const pxPerVerovioUnit = this.verovioWidth > 0 ? 420 / this.verovioWidth : 0.02;
+        
+        // Calculate dimensions in pixels based on viewBox and reference width
+        const width = Math.round(vbWidth * pxPerVerovioUnit);
+        const height = Math.round(width * aspectRatio);
+        
+        // Set width and height in pixels
+        svgElement.setAttribute('width', width + 'px');
+        svgElement.setAttribute('height', height + 'px');
+        
+        console.log('ViewBox:', viewBox, '| Calculated SVG: ', width + 'px x ' + height + 'px');
+      }
+    }
+    
     this.dispatchEvent(new CustomEvent('page-info-update', {
       detail: {
         pageNumber: this.pageNumber,


### PR DESCRIPTION
Implements configurable layout options for controlling how Verovio renders page and system breaks in MEI music notation files. Adds support for all five Verovio break modes with a user-friendly `break-mode` HTML attribute.

## Testing the Break Mode Feature

Test the different break modes using the  
[web component demonstrator](https://edirom.github.io/edirom-web-components/demos/edirom-verovio-renderer.html).

> **Note:** The MEI file used below is **only an example**.  
> You can test the break modes with **any valid MEI file** by providing its URL.

### Step-by-Step Testing Instructions

1. **Open the demonstrator**  
   https://edirom.github.io/edirom-web-components/demos/edirom-verovio-renderer.html

2. **Load an MEI file**
   - In the **“MEI URL”** input field, paste an MEI file URL  
   - Example test file:
     ```
     https://raw.githubusercontent.com/music-encoding/sample-encodings/refs/heads/main/MEI_5.1/Music/Music_structure/multiple_sectionsI.mei
     ```

   - This example file contains **3 `<pb>` elements**, resulting in **4 pages** when page breaks are respected.

3. **Test each break mode**

#### Option A — Using the `break-mode` attribute
- Find the **“break-mode”** input field
- Enter one of:
  - `auto`
  - `encoded`
  - `none`
  - `smart`
  - `line`

#### Option B — Using the `verovio-options` input
- In the **“Verovio Options”** JSON input box, add:

```json
{
  "breaks": "auto"
}
```
Replace "auto" with any of: "encoded", "none", "smart", or "line"

Expected Results

| Break Mode | Expected Behavior                                   | Pages  |
|-----------|------------------------------------------------------|--------|
| `auto`    | Automatic rendering based on page dimensions          | -  |
| `encoded` | Uses the 3 `<pb>` elements from the MEI file          | 4      |
| `none`    | Everything on one page, no breaks                     | 1      |
| `smart`   | Systematic breaks based on musical structure          | Varies |
| `line`    | System breaks only (no page breaks)                   | 1      |

Note: For encoded mode, you'll see exactly 4 pages because this MEI file contains 3 page break markers.
